### PR TITLE
Googleへのリダイレクトを削除

### DIFF
--- a/ShareArticle/ReadWebViewController.swift
+++ b/ShareArticle/ReadWebViewController.swift
@@ -19,7 +19,7 @@ class ReadWebViewController: UIViewController {
     @IBOutlet weak var actionButton: UIBarButtonItem!
     
     var originUrl: URL! // 前のvcから引き継いでくる
-    var currentURL: URL!
+    var currentURL: URL?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -62,8 +62,13 @@ class ReadWebViewController: UIViewController {
     }
     
     private func showUiActivity() {
-        let title = self.webView.stringByEvaluatingJavaScript(from: "document.title") ?? "no-title: cannot get title"
-        let postURL = self.webView.request?.url ?? URL(string: "https://www.google.co.jp/")!
+        guard let title = self.webView.stringByEvaluatingJavaScript(from: "document.title"), let postURL = self.webView.request?.url else {
+
+            let alert = UIAlertController(title: "Error", message: "タイトルまたはリンクが取得できませんでした", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self.present(alert, animated: true, completion: nil)
+            return
+        }
         print(postURL)
         let activityItems: [Any] = [title, postURL]
         let appActivity = [PostFromUIActivity()]
@@ -125,7 +130,7 @@ extension ReadWebViewController: UIWebViewDelegate {
     func webViewDidStartLoad(_ webView: UIWebView) {
         UIApplication.shared.isNetworkActivityIndicatorVisible = true
         setAllControlButtonsStatus()
-        currentURL = self.webView.request?.url ?? URL(string: "https://www.google.co.jp/")!
+        currentURL = self.webView.request?.url
     }
     
     func webViewDidFinishLoad(_ webView: UIWebView) {

--- a/ShareArticle/ReadWebViewController.swift
+++ b/ShareArticle/ReadWebViewController.swift
@@ -62,7 +62,9 @@ class ReadWebViewController: UIViewController {
     }
     
     private func showUiActivity() {
-        guard let title = self.webView.stringByEvaluatingJavaScript(from: "document.title"), let postURL = self.webView.request?.url else {
+        guard
+            let title = self.webView.stringByEvaluatingJavaScript(from: "document.title"),
+            let postURL = self.webView.request?.url else {
 
             let alert = UIAlertController(title: "Error", message: "タイトルまたはリンクが取得できませんでした", preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))


### PR DESCRIPTION
`https://www.google.co.jp`のリンクが勝手にコピーされてるとユーザーとしては、びっくりしたり意図してない結果だと思うので、google.co.jpを削除