### PR TITLE
WIP Web版nippolyにあわせたリデザイン

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,16 +3,24 @@ PODS:
   - AlamofireImage (3.2.0):
     - Alamofire (~> 4.1)
   - OpenGraph (1.0.1)
+  - Realm (2.8.3):
+    - Realm/Headers (= 2.8.3)
+  - Realm/Headers (2.8.3)
+  - RealmSwift (2.8.3):
+    - Realm (= 2.8.3)
 
 DEPENDENCIES:
   - AlamofireImage (~> 3.1)
   - OpenGraph
+  - RealmSwift
 
 SPEC CHECKSUMS:
   Alamofire: f28cdffd29de33a7bfa022cbd63ae95a27fae140
   AlamofireImage: 157ed682cc81d3b9db4fb90c1f12180ac552d93b
   OpenGraph: ab741a1468a28a3cca10a03602034ed1c74b84d3
+  Realm: 3601ef091c8c499a31101d8563b991e75546cdce
+  RealmSwift: 8183818515471b01a99abdd2970f8e4fd52b6f4a
 
-PODFILE CHECKSUM: f5b588f37133f4bf161df702b86e0f03fd08cd4f
+PODFILE CHECKSUM: 8eb31d51213d9416b86f0f4a6d6263d97dd7bcad
 
 COCOAPODS: 1.2.1

--- a/ShareArticle/PostFromUIActivityViewController.swift
+++ b/ShareArticle/PostFromUIActivityViewController.swift
@@ -40,7 +40,7 @@ class PostFromUIActivityViewController: UIViewController {
         
         let mainHeadSeparateView = UIView(frame: CGRect(x: 0, y: 0, width: inputView.bounds.width, height: 1))
         mainHeadSeparateView.frame.origin = CGPoint(x: inputView.frame.origin.x, y: headerView.bottomY)
-        mainHeadSeparateView.backgroundColor = UIColor.gray
+        mainHeadSeparateView.backgroundColor = UIColor.lightGray
         
         let guideTextLabel = UILabel(frame: CGRect(x: 0, y: 0, width: inputView.bounds.width - 4 * 2, height: 20))
         guideTextLabel.frame.origin = CGPoint(x: inputView.frame.origin.x + 4, y: mainHeadSeparateView.bottomY)
@@ -74,8 +74,10 @@ class PostFromUIActivityViewController: UIViewController {
         
         
         /****** mainInput view ******/
-        textView.frame = CGRect(x: 0, y: 0, width: 300 - 4 * 2, height: 100 - 4 * 2)
-        textView.frame.origin = CGPoint(x: 4, y: 4)
+        textView.frame = CGRect(x: 0, y: 0, width: 300 - 10 * 2, height: 190 - 10 * 2)
+        textView.frame.origin = CGPoint(x: 10, y: 10)
+        textView.layer.masksToBounds = true
+        textView.layer.cornerRadius = 3.0
         textView.text = ""
         textView.becomeFirstResponder()
         


### PR DESCRIPTION
## 趣旨

もしアプリのアイコンにnippolyのものを使うのであればもう少しWeb版にテーマカラーやデザインなどに寄せてもいいのかなと思ったのでちょくちょくスキマ時間に直してみようかと。
採用するかどうかは任せるのであくまで提案として扱ってもらえればと思います。

## やったこと

- PostFromUIActivityViewControllerのリデザイン
  - 境界線の色などが少し強い気がするので変更
  - マージンが全般的に狭く窮屈な印象があるので余裕を持たせてみる
  - 全体が角丸なのに中のTextViewの角が目立っているのでしつこくない程度に角丸を適用

## やってみたいこと

- 全般的な配色の変更
  - NavigationBarはnippolyの赤に白をのせる形にする
  - ボタンの配色もそれにあわせて変更
- TableViewにDZNEmptyDatasetを適用してUXの改善
- プラスボタンの他にただWebPageを開いてそこから記事をたどれるボタンがあってもいいんじゃないか？
  - そうするとWKWebViewじゃなくてSFSafariViewを採用しても良さそう
